### PR TITLE
Best effort QOS for controller topics and periodic status messages

### DIFF
--- a/controller/controller_tool/tool/src/py/Controller.py
+++ b/controller/controller_tool/tool/src/py/Controller.py
@@ -176,7 +176,7 @@ class Controller(QObject):
         self.command_writer_listener = CommandWriterListener(self)
         writer_qos = fastdds.DataWriterQos()
         self.publisher.get_default_datawriter_qos(writer_qos)
-        writer_qos.reliability().kind = fastdds.RELIABLE_RELIABILITY_QOS
+        writer_qos.reliability().kind = fastdds.BEST_EFFORT_RELIABILITY_QOS
         writer_qos.durability().kind = fastdds.VOLATILE_DURABILITY_QOS
         writer_qos.history().kind = fastdds.KEEP_LAST_HISTORY_QOS
         writer_qos.history().size = 10
@@ -191,7 +191,7 @@ class Controller(QObject):
         self.status_reader_listener = StatusReaderListener(self)
         reader_qos = fastdds.DataReaderQos()
         self.subscriber.get_default_datareader_qos(reader_qos)
-        reader_qos.reliability().kind = fastdds.RELIABLE_RELIABILITY_QOS
+        reader_qos.reliability().kind = fastdds.BEST_EFFORT_RELIABILITY_QOS
         reader_qos.durability().kind = fastdds.TRANSIENT_LOCAL_DURABILITY_QOS
         reader_qos.history().kind = fastdds.KEEP_LAST_HISTORY_QOS
         reader_qos.history().size = 10

--- a/ddsrecorder/src/cpp/command_receiver/CommandReceiver.cpp
+++ b/ddsrecorder/src/cpp/command_receiver/CommandReceiver.cpp
@@ -175,7 +175,7 @@ bool CommandReceiver::init()
 
     // CREATE THE READER
     DataReaderQos rqos = DATAREADER_QOS_DEFAULT;
-    rqos.reliability().kind = RELIABLE_RELIABILITY_QOS;
+    rqos.reliability().kind = BEST_EFFORT_RELIABILITY_QOS;
     rqos.durability().kind = VOLATILE_DURABILITY_QOS;
     rqos.history().kind = KEEP_LAST_HISTORY_QOS;
     rqos.history().depth = 1; //TODO: increase?
@@ -215,7 +215,7 @@ bool CommandReceiver::init()
 
     // CREATE THE WRITER
     DataWriterQos wqos = DATAWRITER_QOS_DEFAULT;
-    wqos.reliability().kind = RELIABLE_RELIABILITY_QOS;
+    wqos.reliability().kind = BEST_EFFORT_RELIABILITY_QOS;
     wqos.durability().kind = TRANSIENT_LOCAL_DURABILITY_QOS;
     wqos.history().kind = KEEP_LAST_HISTORY_QOS;
     wqos.history().depth = 1;

--- a/ddsrecorder/src/cpp/command_receiver/CommandReceiver.cpp
+++ b/ddsrecorder/src/cpp/command_receiver/CommandReceiver.cpp
@@ -295,7 +295,7 @@ void CommandReceiver::publish_status(
     {
         status.info(info);
     }
-    logUser(
+    logInfo(
         DDSRECORDER_COMMAND_RECEIVER,
         "Publishing status: " << status.previous() << " ---> " << status.current() <<  " with info [" << status.info() <<
             " ].");


### PR DESCRIPTION
Known issue: Variables `command` and `prev_command` are not protected against simultaneous access from Fast DDS threads and `status_publish_thread` which is a periodic thread. We can use a mutex or atomic types to prevent these variables from holding half-updated values, but the risk of such events is very low and the consequence is harmless. More details below:
1. The modification of the two variables only occurs when a command is sent to the DDS Recorder, which does not happen frequently.
2. The rate of publishing the state is 10 Hz which is pretty low.
3. The variables are relatively small.
4. If in rare cases any of these two variables is not valid, there is a switch-case with a default which will return `UNKNOWN` as the state. This is not ideal, but is very unlikely to cause any issues.